### PR TITLE
Skip Deploy Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ jobs:
           cname: ''                  # Default is to not use a cname
           actor: ''                  # Default is the GITHUB_ACTOR
           pre_build_commands: ''     # Installing additional dependencies (Arch Linux)
+          skip_deploy: ''            # Skip the Deploy Step - only build
 ```
 
 To schedule a workflow, you can use the POSIX cron syntax in your workflow file.

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   pre_build_commands:
     description: 'The pre-build commands'
     required: false
+  skip_deploy:
+    description: 'Skip the Deploy Step'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,12 +109,14 @@ build_jekyll || {
 
 cd ${WORKING_DIR}/build
 
-# Check if deploy on the same repository branch
-if [[ "${PROVIDER}" == "github" ]]; then
-  source "${SCRIPT_DIR}/providers/github.sh"
-else
-  echo "${PROVIDER} is an unsupported provider."
-  exit 1
+if [[ ! -z "${INPUT_SKIP_DEPLOY}" ]]; then
+  # Check if deploy on the same repository branch
+  if [[ "${PROVIDER}" == "github" ]]; then
+    source "${SCRIPT_DIR}/providers/github.sh"
+  else
+    echo "${PROVIDER} is an unsupported provider."
+    exit 1
+  fi
 fi
 
 exit $?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,7 +109,7 @@ build_jekyll || {
 
 cd ${WORKING_DIR}/build
 
-if [[ ! -z "${INPUT_SKIP_DEPLOY}" ]]; then
+if [[ -z "${INPUT_SKIP_DEPLOY}" ]]; then
   # Check if deploy on the same repository branch
   if [[ "${PROVIDER}" == "github" ]]; then
     source "${SCRIPT_DIR}/providers/github.sh"


### PR DESCRIPTION
This PR adds an input (`skip_deploy`) that can be used to skip the deploy step -- allowing this action to be used simply to verify that the site builds. 

Example use would be that this action runs on a PR with deploy skipped and when merged it runs on push to main and actually deploys. 

Would close #36 
