### PR TITLE
fix#73: usr: refresh keyring for Arch packages

### DIFF
--- a/script/init_environment.sh
+++ b/script/init_environment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# https://www.reddit.com/r/archlinux/comments/ugcmtn/unable_to_fix_gpg_error_when_upgrading_packages/
+pacman-key --refresh-keys
+
 # Update packages database
 pacman -Syu --noconfirm
 


### PR DESCRIPTION
Relates to #73 

Installing ruby fails with Errors:

> pacman -S --noconfirm ruby2.7 ruby-bundler

> error: ruby-uri: signature from "Levente Polyak (anthraxx)
>        <levente@leventepolyak.net>" is unknown trust
> :: File /var/cache/pacman/pkg/ruby-uri-0.12.1-1-any.pkg.tar.zst is
>         corrupted (invalid or corrupted package (PGP signature)).

Refs:

1. https://www.reddit.com/r/archlinux/comments/ugcmtn/unable_to_fix_gpg_error_when_upgrading_packages/
2. https://forum.manjaro.org/t/error-failed-to-commit-transaction-failed-to-retrieve-some-files/119308/3
3. https://www.reddit.com/r/archlinux/comments/5legoq/trouble_mounting_archchroot/