### PR TITLE
fix: update and cache archlinux-keyring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM archlinux:base-devel
 
+# Update the package repositories and install necessary packages
+RUN pacman -Syu --noconfirm \
+    && pacman -S --noconfirm archlinux-keyring
+
+# Cache the result of refreshing keys
+RUN pacman-key --init \
+    && pacman-key --populate archlinux \
+    && pacman-key --refresh-keys
+
 LABEL version="0.1.0"
 LABEL repository="https://github.com/jeffreytse/jekyll-deploy-action"
 LABEL homepage="https://github.com/jeffreytse/jekyll-deploy-action"


### PR DESCRIPTION
Relates to #73 

Hoping that caching this in the Docker image will reduce subsequent build times.
