### PR TITLE
Increase git post buffer size

### DIFF
--- a/providers/github.sh
+++ b/providers/github.sh
@@ -27,6 +27,7 @@ echo "Deploying to ${REPOSITORY} on branch ${BRANCH}"
 echo "Deploying to ${REMOTE_REPO}"
 
 git config --global init.defaultBranch main && \
+  git config --global http.postBuffer 524288000 && \
   git init && \
   git config user.name "${ACTOR}" && \
   git config user.email "${ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
# Description
I've run into the following error in the build
```
error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400
send-pack: unexpected disconnect while reading sideband packet
fatal: the remote end hung up unexpectedly
```

According to [git config documentation](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httppostBuffer)

> Maximum size in bytes of the buffer used by smart HTTP transports when POSTing data to the remote system. For requests larger than this buffer size, HTTP/1.1 and Transfer-Encoding: chunked is used to avoid creating a massive pack file locally. Default is 1 MiB, which is sufficient for most requests.

<hr>

You can check the error at https://github.com/ambersun1234/ambersun1234.github.io/actions/runs/8483339855/job/23244517355

# Fix
This PR adjust the git post buffer size to `524288000`