### PR TITLE
ruby breaks on the latest archlinux:base-devel image

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -20,6 +20,6 @@ jobs:
           ${{ runner.os }}-cache-
     - uses: ./
       with:
-        provider: 'github'
+        provider: 'test'
         token: ${{ secrets.GITHUB_TOKEN }}
         jekyll_src: './test_site'

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -20,6 +20,6 @@ jobs:
           ${{ runner.os }}-cache-
     - uses: ./
       with:
-        provider: 'test'
+        provider: 'github'
         token: ${{ secrets.GITHUB_TOKEN }}
         jekyll_src: './test_site'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM archlinux:base-devel
+FROM alpine:latest
 
 LABEL version="0.1.0"
 LABEL repository="https://github.com/jeffreytse/jekyll-deploy-action"
 LABEL homepage="https://github.com/jeffreytse/jekyll-deploy-action"
 LABEL maintainer="Jeffrey Tse <jeffreytse.mail@gmail.com>"
+
+RUN apk update && apk add --no-cache bash perl gcc make musl-dev zlib-dev openssl-dev g++
 
 COPY LICENSE.txt README.md /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL repository="https://github.com/jeffreytse/jekyll-deploy-action"
 LABEL homepage="https://github.com/jeffreytse/jekyll-deploy-action"
 LABEL maintainer="Jeffrey Tse <jeffreytse.mail@gmail.com>"
 
-RUN apk update && apk add --no-cache bash perl gcc make musl-dev zlib-dev openssl-dev g++
+RUN apk update && apk add --no-cache bash perl gcc make musl-dev zlib-dev openssl-dev g++ linux-headers
 
 COPY LICENSE.txt README.md /
 

--- a/README.md
+++ b/README.md
@@ -176,16 +176,16 @@ for you:
 
 ```yaml
 # NodeJS
-pre_build_commands: pacman -S --noconfirm nodejs npm
+pre_build_commands: apk add nodejs npm
 
 # Python
-pre_build_commands: pacman -S --noconfirm python
+pre_build_commands: apk add python
 
 # Gem RMagick
-pre_build_commands: pacman -S --noconfirm imagemagick
+pre_build_commands: apk add imagemagick
 
 # Jekyll-Picture-Tag
-pre_build_commands: pacman -S --noconfirm libvips lcms2 openjpeg2 libpng libwebp libheif imagemagick openslide libjxl poppler-glib
+pre_build_commands: apk add vips lcms2 openjpeg libpng libwebp libheif imagemagick openslide libjxl poppler-glib
 ```
 
 If you prefer to deploy your site in SSH approach for better stability, you can

--- a/script/init_environment.sh
+++ b/script/init_environment.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 
-# Generate a default secret key
-# To prevent archlinux-keyring from no secret key available to sign with
-pacman-key --init
-
 # Update packages database
-pacman -Syu --noconfirm
+apk update
 
 # Installing git package
-pacman -S --noconfirm git
+apk add git
 
 # Installing openssh package
 if [[ -n "${SSH_PRIVATE_KEY}" ]]; then
-  pacman -S --noconfirm openssh
+  apk add openssh
 fi
 
 # Install asdf-vm for tools' version management
@@ -29,7 +25,7 @@ source ${ASDF_HOME}/asdf.sh
 ln -s ${ASDF_HOME} ${HOME}/.asdf
 
 # Install ruby environment
-pacman -S --noconfirm libyaml
+apk add yaml-dev
 
 if ! asdf list ruby ${RUBY_VER} &>/dev/null; then
   # Clean up ruby environments avoiding unnecessary cache


### PR DESCRIPTION
This PR aims to fix the issue where ruby breaks on the latest `archlinux:base-devel` image (#98).

Basically, what happens is that Archlinux upgrades recently, and this breaks ruby. Grid search over ruby versions show that all ruby versions are affected, i.e. v3.1.3, v3.1.7, v3.2.0, v3.3.0, and v3.4.3. Here, ruby v3.1.x won't compile on the latest archlinux image; on the other hand, ruby>=3.2 can compile, but gets stuck at building a native gem called `commonmarker`. Therefore, there's no way but to switch to a working OS, and I propose the [`alpine:latest`](https://hub.docker.com/_/alpine) image.

I have deployed my pages using this fix (for the log, see [here](https://github.com/kkew3/kkew3.github.io/actions/runs/14780993579/job/41499704532)).

This will be a breaking change. While I'm not expecting this PR to get merged eventually, I hope it's more or less helpful in solving this issue.